### PR TITLE
kotlin basic<2장> : 코틀린 기초

### DIFF
--- a/src/main/kotlin/Exercise.kt
+++ b/src/main/kotlin/Exercise.kt
@@ -1,0 +1,16 @@
+class MyString {
+    var string = ""
+    infix fun add(other: String) {
+        this.string = this.string + other
+    }
+    companion object {
+        const val A = "A"
+    }
+}
+
+fun main(){
+    val myString = MyString()
+    myString
+    System.out.println(myString.string)
+}
+

--- a/src/main/kotlin/oop/Task.kt
+++ b/src/main/kotlin/oop/Task.kt
@@ -1,5 +1,9 @@
 package oop
 
+fun main(){
+    println( Task("바보",-3).priority)
+
+}
 class Task(val name: String, _priority: Int = DEFAULT_PRIORITY) {
 
     companion object {
@@ -14,7 +18,7 @@ class Task(val name: String, _priority: Int = DEFAULT_PRIORITY) {
         }
 
     private fun validPriority(p: Int) =
-        p.coerceIn(MIN_PRIORITY, MAX_PRIORITY)
+        p.coerceIn(MIN_PRIORITY, MAX_PRIORITY) // 최소보다 작을경우 민 최대보다 클 경우 max 아닐경우 그냥 return
 
 
 //    private fun validPriority(p: Int) = when {


### PR DESCRIPTION
2-1 코틀린 널 허용 타입 사용 : 호출시 ?. 널 허용, !!. 널 아닐시 예외 발생 ?:0 널 일 경우에 0 반환 2-2 자바에 널 허용성 지시자 추가 : 메이븐에서 설정
2-3 자바를 위한 메서드 중복 :  자바를 위한 메소드 중복 @JvmOverloads로 자바에서 코틀린처럼 속성의 기본인자를 할당 가능
   하지만 기본 인자 할당이 불가능해서 함수 중복을 활용해 기본인자를 할당한것처럼 사용
2-4 명시적 타입 변환하기 : 코틀린은 자바와 다르게 짧은 타입을 긴 타입으로 자동 변환이 되지 않아 직접 명시해야한다. 2-5 다른 기수로 출력하기 : toString(radix:Int)를 통해서(2~36)진법 변환 가능 2-6 숫자를 거듭제곱하기 : pow는 double타입으로 사용 가능한 함수이고 kotlin에서 int와 long은 double로 자동 타입 변환이 불가능하다
   infix(Pair(a,b) == a to b 처럼 함수를 더 직관적이고 사용하기 쉽게 수정하는 함수)를
   활용해서 int,long을 double로 변환해서 계산한 뒤에 다시 int,long으로 변환한 함수를 만들어서 사용
2-7 비트 시프트 연산자 사용 :
    shl 부호 있는 왼쪽 시프트 32 = 00100000 32 shl 1 00010000 -일경우 이동후 -
    shr 부호 있는 오른쪽 시프트 32 = 00100000 32 shr 1 01000000 - 일경우 이동후 -
    ushr 부호 없는 오른쪽 시프트 -5 = 00000101 -5 ushr 1 0x7fff_fffd(2_147_483_646)
    ushr 활용: Int의 최대값이 넘어갈 경우 -로 바뀌게 되는데 ushr를 사용할시에 원하는 결과를 호출 할 수 있다.
2-8 비트 불리언 연산자 사용 :
    n1 0000_1100  n2 0001_1001
    n1 and n2 = 0000_1000 겹치는것만
    n1 or n2  = 0001_1101 모두
    n1 xor n2 = 0001_0101 안겹치는 모두
2-9 to로 Pair 인스턴스 생성 : 아까 메모한 infix 특징을 살린 대표적인 예시 Pair("a",3) == "a" to 3
   mapOf = fun <K, V> mapOf(vararg pairs:Pair<K, V):Map<K,V>  vararg를 통해 속성에 Pair타입을 무한정(실제 무한은 아니다) 사용
   이를 활용해 mapOf("a" to 1 ,"b" to 2, ....)로 사용 가능하다.